### PR TITLE
Bug of height of screen view

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -14,7 +14,7 @@ function SlideLayout({ children }: PropsWithChildren) {
 	const { prev, next, slides, currentSlide } = slidesStore;
 
 	return (
-		<div className="flex h-[100vh] h-[100svw] w-screen flex-col">
+		<div className="flex h-[100vh] w-screen flex-col">
 			<div className="columns-2 bg-base-300 px-2 text-sm font-bold text-base-content">
 				<Link href="/" className="block text-left">
 					Taller de React


### PR DESCRIPTION
There was a bug with the height of screen view on Firefox browser and Mobile device. 
Before:
![Screen Shot 2022-11-07 at 15 14 48](https://user-images.githubusercontent.com/41976055/200384554-ee79ac1e-ffa7-4ce6-b2ee-6a17d0cd042b.png)

After: 
![Screen Shot 2022-11-07 at 15 14 59](https://user-images.githubusercontent.com/41976055/200384576-ce9cb029-2637-46b4-a7b8-15504d606e5e.png)

